### PR TITLE
Explain value vs pointer receivers in struct-example.go

### DIFF
--- a/struct-example.go
+++ b/struct-example.go
@@ -7,11 +7,17 @@ type Rectangle struct {
 	Width  int
 }
 
+// Enlarge demonstrates pass-by-value for the receiver.
+// Changes made to r inside this method are made to a copy of the original Rectangle,
+// so the original Rectangle instance is not modified.
 func (r Rectangle) Enlarge(factor int) {
 	r.Height = r.Height * factor
 	r.Width = r.Width * factor
 }
 
+// EnlargeP demonstrates pass-by-pointer for the receiver.
+// Changes made to r inside this method are made to the original Rectangle instance
+// because r is a pointer to that instance.
 func (r *Rectangle) EnlargeP(factor int) {
 	r.Height = r.Height * factor
 	r.Width = r.Width * factor
@@ -21,11 +27,16 @@ func main() {
 
 	rect := Rectangle{Height: 10, Width: 10}
 
+	fmt.Println("Initial rectangle:", rect) // Expected: {10 10}
+
 	rect.Enlarge(2)
-	fmt.Println(rect)
+	// After calling Enlarge (value receiver), rect should be unchanged
+	// because Enlarge operates on a copy.
+	fmt.Println("After Enlarge(2):", rect) // Expected: {10 10}
 
 	rect.EnlargeP(5)
-
-	fmt.Println(rect)
+	// After calling EnlargeP (pointer receiver), rect should be changed
+	// because EnlargeP operates on the original instance via a pointer.
+	fmt.Println("After EnlargeP(5):", rect) // Expected: {50 50}
 
 }


### PR DESCRIPTION
Added comments to the Rectangle struct's methods (Enlarge and EnlargeP) and to the main function to clarify the difference in behavior when using value receivers versus pointer receivers.

- Enlarge (value receiver) operates on a copy, so the original instance is not modified.
- EnlargeP (pointer receiver) operates on the original instance, so it is modified.

The main function's print statements demonstrate this behavior, and comments were added to highlight the expected output and reasoning.